### PR TITLE
hotfix: added check if class exist for v4.4.0

### DIFF
--- a/Deadstream/src/main/kotlin/com/Deadstream/DeadstreamProvider.kt
+++ b/Deadstream/src/main/kotlin/com/Deadstream/DeadstreamProvider.kt
@@ -10,13 +10,35 @@ import com.lagradost.cloudstream3.extractors.Chillx
 
 @CloudstreamPlugin
 class DeadstreamProvider: Plugin() {
+    private fun classExist(className: String) : Boolean {
+        try {
+            Class.forName(className, false, ClassLoader.getSystemClassLoader())
+        } catch (e: ClassNotFoundException) {
+            return false
+        }
+
+        return true
+    }
+
     override fun load(context: Context) {
         registerMainAPI(Deadstream())
         registerExtractorAPI(Chillx())
         registerExtractorAPI(Voe())
         registerExtractorAPI(StreamWishExtractor())
         registerExtractorAPI(MyFileMoon())
-        registerExtractorAPI(VidHidePro())
+        /*
+            Check if class exists before load
+            v.4.4.0 released 20240725
+            Class added on 20240819
+
+            7bdf1461 (Added VidHidePro Extractor (#1286), 2024-08-19)
+            library/src/commonMain/kotlin/com/lagradost/cloudstream3/extractors/VidHidePro.kt
+
+         */
+        if (classExist("com.lagradost.cloudstream3.extractors.VidHidePro")) {
+            registerExtractorAPI(VidHidePro())
+        }
+
         //registerExtractorAPI(AbyssCdn())
     }
 }


### PR DESCRIPTION
![317100555-a675afc8-5eef-48a4-92fe-9dcd21e1b0e9](https://github.com/user-attachments/assets/182f7f51-e946-418f-bac8-42b6f373e7a3)

> java.lang.NoClassDefFoundError: Failed resolution of: Lcom/lagradost/cloudstream3/extractors/VidHidePro;